### PR TITLE
fix: 修复DjangoFormatter上报事件覆盖user_identify_type字段

### DIFF
--- a/bk_audit/contrib/django/formatters.py
+++ b/bk_audit/contrib/django/formatters.py
@@ -77,7 +77,6 @@ class DjangoFormatter(Formatter):
             audit_context.access_type = self.get_access_type(request)
             audit_context.access_source_ip = self.get_access_source_ip(request)
             audit_context.access_user_agent = self.get_access_user_agent(request)
-            audit_context.user_identify_type = UserIdentifyTypeEnum.UNKNOWN
             audit_context.user_identify_tenant_id = DEFAULT_EMPTY_VALUE
         return super(DjangoFormatter, self).build_event(
             action=action,


### PR DESCRIPTION
在审计上下文 AuditContext 定义的时候，已经默认定义了 user_identify_type 内容，上报时如果用户不设置字段就直接会使用默认的 UNKNOWN -1